### PR TITLE
AlmostUnified integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ repositories {
 dependencies {
     minecraft "net.minecraftforge:forge:${forge_version}"
 
-    compileOnly(fg.deobf("com.almostreliable.mods:almostunified-forge:${almostunified_version}"))
+    compileOnly fg.deobf("com.almostreliable.mods:almostunified-forge:${almostunified_version}")
 }
 
 jar {

--- a/build.gradle
+++ b/build.gradle
@@ -57,8 +57,19 @@ minecraft {
     }
 }
 
+repositories {
+    maven {
+        url = 'https://maven.blamejared.com/'
+        content {
+            includeGroup "com.almostreliable.mods"
+        }
+    }
+}
+
 dependencies {
     minecraft "net.minecraftforge:forge:${forge_version}"
+
+    compileOnly(fg.deobf("com.almostreliable.mods:almostunified-forge:${almostunified_version}"))
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,3 +4,4 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 
 forge_version=1.19.2-43.1.1
+almostunified_version=1.19.2-0.3.4

--- a/src/main/java/com/blakebr0/cucumber/compat/almostunified/AlmostUnifiedAdapter.java
+++ b/src/main/java/com/blakebr0/cucumber/compat/almostunified/AlmostUnifiedAdapter.java
@@ -8,14 +8,13 @@ import net.minecraft.world.item.Item;
 import net.minecraftforge.fml.ModList;
 
 public class AlmostUnifiedAdapter {
-
     public static boolean isLoaded() {
         return ModList.get().isLoaded("almostunified");
     }
 
     public static Item getPreferredItemForTag(String tagId) {
         if (isLoaded()) {
-            TagKey<Item> tagKey = TagKey.create(Registry.ITEM_REGISTRY, new ResourceLocation(tagId));
+            var tagKey = TagKey.create(Registry.ITEM_REGISTRY, new ResourceLocation(tagId));
             return Adapter.getPreferredItemForTag(tagKey);
         }
 

--- a/src/main/java/com/blakebr0/cucumber/compat/almostunified/AlmostUnifiedAdapter.java
+++ b/src/main/java/com/blakebr0/cucumber/compat/almostunified/AlmostUnifiedAdapter.java
@@ -1,0 +1,30 @@
+package com.blakebr0.cucumber.compat.almostunified;
+
+import com.almostreliable.unified.api.AlmostUnifiedLookup;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.Item;
+import net.minecraftforge.fml.ModList;
+
+public class AlmostUnifiedAdapter {
+
+    public static boolean isLoaded() {
+        return ModList.get().isLoaded("almostunified");
+    }
+
+    public static Item getPreferredItemForTag(String tagId) {
+        if (isLoaded()) {
+            TagKey<Item> tagKey = TagKey.create(Registry.ITEM_REGISTRY, new ResourceLocation(tagId));
+            return Adapter.getPreferredItemForTag(tagKey);
+        }
+
+        return null;
+    }
+
+    private static class Adapter {
+        private static Item getPreferredItemForTag(TagKey<Item> tag) {
+            return AlmostUnifiedLookup.INSTANCE.getPreferredItemForTag(tag);
+        }
+    }
+}

--- a/src/main/java/com/blakebr0/cucumber/crafting/TagMapper.java
+++ b/src/main/java/com/blakebr0/cucumber/crafting/TagMapper.java
@@ -1,6 +1,7 @@
 package com.blakebr0.cucumber.crafting;
 
 import com.blakebr0.cucumber.Cucumber;
+import com.blakebr0.cucumber.compat.almostunified.AlmostUnifiedAdapter;
 import com.blakebr0.cucumber.config.ModConfigs;
 import com.google.common.base.Stopwatch;
 import com.google.gson.Gson;
@@ -96,6 +97,11 @@ public class TagMapper {
     }
 
     public static Item getItemForTag(String tagId) {
+        var preferredItem = AlmostUnifiedAdapter.getPreferredItemForTag(tagId);
+        if (preferredItem != null) {
+            return preferredItem;
+        }
+
         if (TAG_TO_ITEM_MAP.containsKey(tagId)) {
             var id = TAG_TO_ITEM_MAP.get(tagId);
             return ForgeRegistries.ITEMS.getValue(new ResourceLocation(id));
@@ -153,7 +159,7 @@ public class TagMapper {
         var tags = ForgeRegistries.ITEMS.tags();
 
         assert tags != null;
-        
+
         var item = tags.getTag(key).stream().min((item1, item2) -> {
             var id1 = ForgeRegistries.ITEMS.getKey(item1);
             var index1 = id1 != null ? mods.indexOf(id1.getNamespace()) : -1;


### PR DESCRIPTION
This PR introduces integration for Almost Unified as proposed in #20.

It is loaded as a compile-only dependency. The `AlmostUnifiedAdapter` makes sure the mod is actually loaded before accessing internals within the nested class to avoid a crash.

When the mod isn't installed or the API returned no result (`null`), it will use the previous behavior of the library.

An 1.19.3 version of Almost Unified will follow in a few hours and the changes should be cherry-pickable once released.