### PR TITLE
update Almost Unified integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ dependencies {
     implementation "dev.latvian.mods:rhino-neoforge:${rhino_version}"
     implementation "dev.architectury:architectury-neoforge:${architectury_version}"
 
-    compileOnly "com.almostreliable.mods:almostunified-forge:${almostunified_version}"
+    compileOnly "com.almostreliable.mods:almostunified-neoforge:${almostunified_version}:api"
 }
 
 tasks.withType(ProcessResources).configureEach {

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ neo_version=21.1.18
 parchment_minecraft_version=1.21
 parchment_mappings_version=2024.07.28
 
-almostunified_version=1.20.1-0.5.0
+almostunified_version=1.21.1-1.0.0
 architectury_version=13.0.6
 kubejs_version=2100.7.0-build.119
 rhino_version=2005.2.3-build.3

--- a/src/main/java/com/blakebr0/cucumber/compat/almostunified/AlmostUnifiedAdapter.java
+++ b/src/main/java/com/blakebr0/cucumber/compat/almostunified/AlmostUnifiedAdapter.java
@@ -1,6 +1,6 @@
 package com.blakebr0.cucumber.compat.almostunified;
 
-import com.almostreliable.unified.api.AlmostUnifiedLookup;
+import com.almostreliable.unified.api.AlmostUnified;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.ItemTags;
 import net.minecraft.tags.TagKey;
@@ -22,7 +22,7 @@ public class AlmostUnifiedAdapter {
 
     private static class Adapter {
         private static Item getPreferredItemForTag(TagKey<Item> tag) {
-            return AlmostUnifiedLookup.INSTANCE.getPreferredItemForTag(tag);
+            return AlmostUnified.INSTANCE.getTagTargetItem(tag);
         }
     }
 }


### PR DESCRIPTION
This pull requests updates the Almost Unified integration to the newly 1.0.0 release for 1.21+. The mod now has a proper API. This was necessary to avoid breaking changes in the future. The downside is that we need to update existing integrations now.