### PR TITLE
26.1 fix random tooltip crash

### DIFF
--- a/src/main/java/com/blakebr0/cucumber/client/handler/TagTooltipHandler.java
+++ b/src/main/java/com/blakebr0/cucumber/client/handler/TagTooltipHandler.java
@@ -25,6 +25,10 @@ public final class TagTooltipHandler {
 
         if (Minecraft.getInstance().options.advancedItemTooltips) {
             var stack = event.getItemStack();
+            if (stack.isEmpty()) { // Look, I don't know how, but going over the item's stack limit makes this air?
+                return;
+            }
+
             var block = Block.byItem(stack.getItem());
 
             var blockTags = block == Blocks.AIR ? List.of() : block.defaultBlockState().tags()


### PR DESCRIPTION
maybe a NeoForge issue, i dont fuckin know

using Sophisticated Storage with a stack upgrade go over the item's stack limit, and Apotheosis' "link hovered item to chat", hover over the item in chat
for some reason `event.getItemStack()` turns into air

also open to the idea Apotheosis' clamping is somehow messed up, but i just wanna stop crashing

more specifically the error occurs at `FluidHelper.getFluidTags(stack)`, because `ItemAccess.forStack(stack)` doesn't like being handed an empty stack